### PR TITLE
Remove blank metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ assert(
       'Any dispute or controversy arising under or in connection ' +
       'with this ', { use: 'Agreement' }, ' shall be settled ' +
       'exclusively by arbitration in the ',
-      { blank: 'Arbitration Venue' }, ', in accordance with the ' +
+      { blank: '' }, ', in accordance with the ' +
       'applicable rules of the American Arbitration Association ' +
       'then in effect.' ] }),
   'valid forms include the real-world example')
@@ -113,7 +113,7 @@ assert(
 ## Blanks
 
 ```javascript
-assert(valid.blank({ blank: 'A' }))
+assert(valid.blank({ blank: '' }))
 ```
 
 ## Definitions

--- a/index.js
+++ b/index.js
@@ -36,10 +36,18 @@ var simpleObject = function(permittedKey) {
 
 exports.term = exports.heading = exports.value = term
 
-var blank = exports.blank = simpleObject('blank')
 var definition = exports.definition = simpleObject('definition')
 var reference = exports.reference = simpleObject('reference')
 var use = exports.use = simpleObject('use')
+
+function isEmptyString(argument) {
+  return ( argument === '' ) }
+
+var blank = exports.blank = function(argument) {
+  return (
+    object(argument) &&
+    keyCount(argument) === 1 &&
+    hasProperty(argument, 'blank', isEmptyString) ) }
 
 var form
 


### PR DESCRIPTION
This pull request requires all fill-in-the-blanks to be encoded with empty string labels:

```json
{ "content": [ { "blank": "" } ] }
```

At present, blanks must have a non-empty label string:

```json
{ "content": [ { "blank": "Seller Name" } ] }
```

There are a few problems with the current approach:

1. Two forms can vary only by the value of a blank label string.

2. Recipients of completed forms can't guess what labels blanks had before they were completed.

3. The content of blank label strings is entirely arbitrary.

There are also a few benefits:

1. User interfaces for filling out blanks are trivial, since a label-to-value map is all that's needed. CLI does this with `--blanks values.json`. commonform.org does this with a table of form inputs.

2. Labeled blanks correspond well to current practice in Word. "[•]" is fairly common, but "[purchase price]" and the like are the norm.

Essentially, the current blanks-with-labels offer benefits from encoding metadata into the forms. This breaks with the general approach of keeping forms themselves as minimal as possible, and of avoiding situations where semantically equivalent forms hash differently.

Annotations could provide all of the benefits of labels, less a deterministic way to reference blanks to be filled in. For automatic completion, we would need something like `[FORM_DIGEST, BLANK_INDEX, VALUE]`. [markup](https://npmjs.com/packages/commonform-markup) might make this easier for command-line users by emitting both a form and a list of annotations corresponding to comments and blank metadata.

@anseljh, I'd be really interested in your opinion on this.