### PR TITLE
Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,34 @@ assert(
     }
   )
 )
+
+assert(
+  !validate.form(
+    {
+      content: [
+        {
+          heading: 'Warranty Disclaimer',
+          repository: 'api.commonform.org',
+          publisher: 'kemitchell',
+          project: 'orthodox-software-copyright-license',
+          edition: '1e',
+          upgrade: 'yes',
+          substitutions: {
+            terms: {
+              'Licensor': 'Vendor',
+              'Licensee': 'Customer',
+              'Program': 'Software'
+            },
+            headings: {
+              'Express Warranties': 'Guarantees'
+            }
+          }
+        }
+      ]
+    },
+    false // Do not allow components.
+  )
+)
 ```
 
 The `upgrade` flag indicates that the form should [upgrade]
@@ -591,7 +619,8 @@ assert(
           }
         }
       ]
-    }
+    },
+    true // Allow components.
   )
 )
 
@@ -615,7 +644,8 @@ assert(
         },
         ' <- that was a space'
       ]
-    }
+    },
+    true // Allow components.
   )
 )
 ```

--- a/README.md
+++ b/README.md
@@ -562,8 +562,8 @@ assert(
           }
         }
       ]
-    },
-    false // Do not allow components.
+    }
+    // Do not allow components.
   )
 )
 ```
@@ -620,7 +620,7 @@ assert(
         }
       ]
     },
-    true // Allow components.
+    {allowComponents: true}
   )
 )
 
@@ -645,7 +645,7 @@ assert(
         ' <- that was a space'
       ]
     },
-    true // Allow components.
+    {allowComponents: true}
   )
 )
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-```javascript
-var validate = require('commonform-validate')
-```
-
 Common Form represents legal forms, and pieces of legal forms, as
 objects following a single, strict schema.  This package exports a
 function, `validate.form(object)` that returns `true` if `object`
@@ -45,6 +41,8 @@ For example:
 Becomes:
 
 ```javascript
+var validate = require('commonform-validate')
+
 assert(
   validate.form(
     {

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ assert(
   validate.component(
     {
       heading: 'Warranty Disclaimer',
-      repository: 'commonform.org',
+      repository: 'api.commonform.org',
       publisher: 'kemitchell',
       project: 'orthodox-software-copyright-license',
       edition: '1e',
@@ -545,7 +545,7 @@ form will [upgrade] automatically to later published editions.
 assert(
   validate.component(
     {
-      repository: 'commonform.org',
+      repository: 'api.commonform.org',
       publisher: 'kemitchell',
       project: 'orthodox-software-copyright-license',
       edition: '1e',
@@ -569,7 +569,7 @@ assert(
       content: [
         'this is a space -> ',
         {
-          repository: 'commonform.org',
+          repository: 'api.commonform.org',
           publisher: 'kemitchell',
           project: 'orthodox-software-copyright-license',
           edition: '1e',
@@ -589,7 +589,7 @@ assert(
     {
       content: [
         {
-          repository: 'commonform.org',
+          repository: 'api.commonform.org',
           publisher: 'kemitchell',
           project: 'orthodox-software-copyright-license',
           edition: '1e',

--- a/README.md
+++ b/README.md
@@ -511,6 +511,93 @@ assert(
 )
 ```
 
+## Components
+
+Children can also be incorporated by reference:
+
+```javascript
+assert(
+  validate.component(
+    {
+      heading: 'Warranty Disclaimer',
+      repository: 'commonform.org',
+      publisher: 'kemitchell',
+      project: 'orthodox-software-copyright-license',
+      edition: '1e',
+      exact: 'yes',
+      substitutions: {
+        'Licensor': 'Vendor',
+        'Licensee': 'Customer',
+        'Program': 'Software'
+      }
+    }
+  )
+)
+
+assert(
+  validate.component(
+    {
+      repository: 'commonform.org',
+      publisher: 'kemitchell',
+      project: 'orthodox-software-copyright-license',
+      edition: '1e',
+      substitutions: {
+        'Licensor': 'Vendor',
+        'Licensee': 'Customer',
+        'Program': 'Software'
+      }
+    }
+  )
+)
+```
+
+Strings surrounding a component cannot run up to the component
+with space:
+
+```javascript
+assert(
+  !validate.form(
+    {
+      content: [
+        'this is a space -> ',
+        {
+          repository: 'commonform.org',
+          publisher: 'kemitchell',
+          project: 'orthodox-software-copyright-license',
+          edition: '1e',
+          substitutions: {
+            'Licensor': 'Vendor',
+            'Licensee': 'Customer',
+            'Program': 'Software'
+          }
+        }
+      ]
+    }
+  )
+)
+
+assert(
+  !validate.form(
+    {
+      content: [
+        {
+          repository: 'commonform.org',
+          publisher: 'kemitchell',
+          project: 'orthodox-software-copyright-license',
+          edition: '1e',
+          substitutions: {
+            'Licensor': 'Vendor',
+            'Licensee': 'Customer',
+            'Program': 'Software'
+          }
+        },
+        ' <- that was a space'
+      ]
+    }
+  )
+)
+```
+
 # Conspicuous Provisions
 
 Forms that must be typeset conspicuously have a `conspicuous` property

--- a/README.md
+++ b/README.md
@@ -533,7 +533,15 @@ assert(
     }
   )
 )
+```
 
+The `exact` flag indicates that the form incorporates only
+the indicated edition of the component.  Without `exact`, the
+form will [upgrade] automatically to later published editions.
+
+[upgrade]: https://www.npmjs.com/package/reviewers-edition-upgrade
+
+```javascript
 assert(
   validate.component(
     {

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ assert(
       publisher: 'kemitchell',
       project: 'orthodox-software-copyright-license',
       edition: '1e',
-      exact: 'yes',
+      upgrade: 'yes',
       substitutions: {
         terms: {
           'Licensor': 'Vendor',
@@ -540,9 +540,9 @@ assert(
 )
 ```
 
-The `exact` flag indicates that the form incorporates only
-the indicated edition of the component.  Without `exact`, the
-form will [upgrade] automatically to later published editions.
+The `upgrade` flag indicates that the form should [upgrade]
+automatically to later published editions.  Without `upgrade`, the
+form will incorporate only the indicated edition.
 
 [upgrade]: https://www.npmjs.com/package/reviewers-edition-upgrade
 

--- a/README.md
+++ b/README.md
@@ -513,6 +513,8 @@ assert(
 
 ## Components
 
+The validation routine optionally permits components.
+
 Children can also be incorporated by reference:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -526,9 +526,14 @@ assert(
       edition: '1e',
       exact: 'yes',
       substitutions: {
-        'Licensor': 'Vendor',
-        'Licensee': 'Customer',
-        'Program': 'Software'
+        terms: {
+          'Licensor': 'Vendor',
+          'Licensee': 'Customer',
+          'Program': 'Software'
+        },
+        headings: {
+          'Express Warranties': 'Guarantees'
+        }
       }
     }
   )
@@ -550,9 +555,12 @@ assert(
       project: 'orthodox-software-copyright-license',
       edition: '1e',
       substitutions: {
-        'Licensor': 'Vendor',
-        'Licensee': 'Customer',
-        'Program': 'Software'
+        terms: {
+          'Licensor': 'Vendor',
+          'Licensee': 'Customer',
+          'Program': 'Software'
+        },
+        headings: {}
       }
     }
   )
@@ -574,9 +582,12 @@ assert(
           project: 'orthodox-software-copyright-license',
           edition: '1e',
           substitutions: {
-            'Licensor': 'Vendor',
-            'Licensee': 'Customer',
-            'Program': 'Software'
+            terms: {
+              'Licensor': 'Vendor',
+              'Licensee': 'Customer',
+              'Program': 'Software'
+            },
+            headings: {}
           }
         }
       ]
@@ -594,9 +605,12 @@ assert(
           project: 'orthodox-software-copyright-license',
           edition: '1e',
           substitutions: {
-            'Licensor': 'Vendor',
-            'Licensee': 'Customer',
-            'Program': 'Software'
+            terms: {
+              'Licensor': 'Vendor',
+              'Licensee': 'Customer',
+              'Program': 'Software'
+            },
+            headings: {}
           }
         },
         ' <- that was a space'

--- a/index.js
+++ b/index.js
@@ -20,6 +20,12 @@ var string = require('is-string')
 var tlds = require('tlds')
 var revedParse = require('reviewers-edition-parse')
 
+var ALL_LOWER_ALPHA = /^[a-z]+$/
+
+var ASCII_TLDS = tlds.filter(function (tld) {
+  return ALL_LOWER_ALPHA.test(tld)
+})
+
 var keyCount = function (argument) {
   return Object.keys(argument).length
 }
@@ -107,10 +113,10 @@ var component = exports.component = function (argument) {
         var split = value.split('.')
         if (split.length <= 2) return false
         var validNames = split.slice(0, -1).every(function (name) {
-          return /^[a-z]+$/.test(name)
+          return ALL_LOWER_ALPHA.test(name)
         })
         if (!validNames) return false
-        if (tlds.indexOf(split[split.length - 1]) === -1) return false
+        if (ASCII_TLDS.indexOf(split[split.length - 1]) === -1) return false
         return true
       }) &&
       hasProperty(argument, 'publisher', function (value) {

--- a/index.js
+++ b/index.js
@@ -105,9 +105,12 @@ var component = exports.component = function (argument) {
       hasProperty(argument, 'repository', function repository (value) {
         if (!string(value)) return false
         var split = value.split('.')
-        if (split.length !== 2) return false
-        if (!/^[a-z]+$/.test(split[0])) return false
-        if (tlds.indexOf(split[1]) === -1) return false
+        if (split.length <= 2) return false
+        var validNames = split.slice(0, -1).every(function (name) {
+          return /^[a-z]+$/.test(name)
+        })
+        if (!validNames) return false
+        if (tlds.indexOf(split[split.length - 1]) === -1) return false
         return true
       }) &&
       hasProperty(argument, 'publisher', function (value) {

--- a/index.js
+++ b/index.js
@@ -166,10 +166,14 @@ function termMapping (argument) {
 }
 
 var content = exports.content = (function () {
-  var predicates = [blank, child, component, definition, reference, text, use]
+  var predicates = [blank, child, definition, reference, text, use]
 
-  return function (argument) {
-    return predicates.some(function (predicate) {
+  return function (argument, allowComponents) {
+    return (
+      allowComponents
+        ? predicates.concat(component)
+        : predicates
+    ).some(function (predicate) {
       return predicate(argument)
     })
   }
@@ -222,14 +226,16 @@ form = exports.form = (function () {
     })
   }
 
-  return function (argument) {
+  return function (argument, allowComponents) {
     return (
       object(argument) &&
       hasProperty(argument, 'content', function (elements) {
         return (
           array(elements) &&
           elements.length > 0 &&
-          elements.every(content) &&
+          elements.every(function (element) {
+            return content(element, allowComponents)
+          }) &&
           !contiguous(elements, string) &&
           !contiguous(elements, blank) &&
           !spaceAbuttingChild(elements) &&

--- a/index.js
+++ b/index.js
@@ -168,9 +168,9 @@ function termMapping (argument) {
 var content = exports.content = (function () {
   var predicates = [blank, child, definition, reference, text, use]
 
-  return function (argument, allowComponents) {
+  return function (argument, options) {
     return (
-      allowComponents
+      (options && options.allowComponents)
         ? predicates.concat(component)
         : predicates
     ).some(function (predicate) {
@@ -226,7 +226,7 @@ form = exports.form = (function () {
     })
   }
 
-  return function (argument, allowComponents) {
+  return function (argument, options) {
     return (
       object(argument) &&
       hasProperty(argument, 'content', function (elements) {
@@ -234,7 +234,7 @@ form = exports.form = (function () {
           array(elements) &&
           elements.length > 0 &&
           elements.every(function (element) {
-            return content(element, allowComponents)
+            return content(element, options)
           }) &&
           !contiguous(elements, string) &&
           !contiguous(elements, blank) &&

--- a/index.js
+++ b/index.js
@@ -125,9 +125,9 @@ var component = exports.component = function (argument) {
       hasProperty(argument, 'substitutions', function (value) {
         return (
           object(value) &&
-          Object.keys(value).every(function (key) {
-            return term(key) && term(value[key])
-          })
+          hasProperty(value, 'terms', termMapping) &&
+          hasProperty(value, 'headings', termMapping) &&
+          keyCount(value) === 2
         )
       })
     ) &&
@@ -147,6 +147,15 @@ var component = exports.component = function (argument) {
       )
     ) &&
     true
+  )
+}
+
+function termMapping (argument) {
+  return (
+    object(argument) &&
+    Object.keys(argument).every(function (key) {
+      return term(key) && term(argument[key])
+    })
   )
 }
 

--- a/index.js
+++ b/index.js
@@ -142,13 +142,13 @@ var component = exports.component = function (argument) {
       (
         keyCount(argument) === 6 &&
         (
-          argument.exact === 'yes' ||
+          argument.upgrade === 'yes' ||
           hasProperty(argument, 'heading', term)
         )
       ) ||
       (
         keyCount(argument) === 7 &&
-        argument.exact === 'yes' &&
+        argument.upgrade === 'yes' &&
         hasProperty(argument, 'heading', term)
       )
     ) &&

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "devDependencies": {
     "defence-cli": "~1.0.1",
     "replace-require-self": "~1.0.0",
-    "standard": "^7.1.2"
+    "standard": "^7.1.2",
+    "standard-markdown": "^4.0.2"
   },
   "files": [
     "LICENSE",
@@ -33,7 +34,7 @@
   "license": "Apache-2.0",
   "repository": "commonform/commonform-validate",
   "scripts": {
-    "lint": "standard",
+    "lint": "standard && standard-markdown",
     "test": "defence README.md | replace-require-self | node"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "contiguous": "1.0.1",
     "is-array": "1.0.1",
     "is-object": "1.0.1",
-    "is-string": "1.0.4"
+    "is-string": "1.0.4",
+    "reviewers-edition-parse": "^2.0.6",
+    "tlds": "^1.199.0"
   },
   "devDependencies": {
     "defence-cli": "~1.0.1",


### PR DESCRIPTION
This pull request extends the current schema to allow a new kind of child element: components. It's the most significant schema change in some time.

Components refer to forms published to a repository like api.commonform.org. Forms can now reference them by repository hostname, publisher name, project name, and edition. With `exact`, the reference is to the specifically listed edition only. Otherwise, the form should upgrade automatically from the listed edition to the latest edition available, according to [Reviewers Edition](https://www.npmjs.com/package/reviewers-edition-upgrade)'s semantics.

Components must also have a `substitutions` object mapping terms defined within the component to terms defined in the containing form. I recently [blogged about this approach](https://writing.kemitchell.com/2018/01/15/Transparent-Contract-Components.html).

Components can have headings, just like children.